### PR TITLE
!!! Fixed photon content width issue, remove yoast function & added submenu icon

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -320,6 +320,16 @@ function zerif_scripts() {
 }
 add_action('wp_enqueue_scripts', 'zerif_scripts');
 
+function zerif_adjust_content_width() {
+    global $content_width;
+
+	$zerif_change_to_full_width = get_theme_mod( 'zerif_change_to_full_width' );
+    if ( is_page_template( 'template-fullwidth.php' ) || is_page_template( 'template-fullwidth-no-title.php' ) || is_page_template( 'woocommerce.php' ) || is_page_template( 'single-download.php' ) || ( is_page_template( 'page.php' ) && !empty($zerif_change_to_full_width) ) )
+	    $content_width = 1110;
+
+}
+add_action( 'template_redirect', 'zerif_adjust_content_width' );
+
 add_action('tgmpa_register', 'zerif_register_required_plugins');
 
 function zerif_register_required_plugins() {	

--- a/functions.php
+++ b/functions.php
@@ -320,6 +320,10 @@ function zerif_scripts() {
 }
 add_action('wp_enqueue_scripts', 'zerif_scripts');
 
+
+/**
+ * Adjust content width based on template.
+ */
 function zerif_adjust_content_width() {
     global $content_width;
 
@@ -329,6 +333,16 @@ function zerif_adjust_content_width() {
 
 }
 add_action( 'template_redirect', 'zerif_adjust_content_width' );
+
+
+/**
+ * Remove Yoast rel="prev/next" link from header
+ */
+function zerif_remove_yoast_rel_link() {
+	return false;
+}
+add_filter( 'wpseo_prev_rel_link', 'zerif_remove_yoast_rel_link' );
+add_filter( 'wpseo_next_rel_link', 'zerif_remove_yoast_rel_link' );
 
 add_action('tgmpa_register', 'zerif_register_required_plugins');
 

--- a/style.css
+++ b/style.css
@@ -791,6 +791,17 @@ a:active {
 	float: left;
 	width: 100%;
 }
+
+.nav .has_children > a:after{
+	content: '\f0d7';
+	font-family: FontAwesome;
+	margin: 0 0 0 6px;
+	color: inherit;
+}
+    
+.nav .sub-menu .has_children > a:after{
+	content: '\f0da';
+}
  /*---------------------------------------
  **   6.0 Accessibility                   -----
 -----------------------------------------*/

--- a/style.css
+++ b/style.css
@@ -3381,6 +3381,14 @@ article .posted-on a:hover{
 .entry-content p {
 	text-align:justify;
 }
+.entry-content blockquote {
+	font: 14px/22px normal helvetica, sans-serif;
+	margin-top: 10px;
+	margin-bottom: 10px;
+	margin-left: 10px;
+	padding-left: 15px;
+	border-left: 3px solid #e96656;
+} 
 .post-img-wrap-large a img{
 	max-width: 100%;
 	width: 100%;


### PR DESCRIPTION
Fixed issue with Jetpack's Photon rendering small photos on full width pages. Close https://github.com/Codeinwp/zerif-lite/issues/398

See commits for more info.

@rodica-andronache 
