### PR TITLE
W3 Total cache - Minify Auto bug on js/zerif.js on function zerifsubmenuorientation

### DIFF
--- a/js/zerif.js
+++ b/js/zerif.js
@@ -745,9 +745,6 @@ function type_view() {
 
 
 /* Menu levels */
-jQuery( document ).ready( function() {
-  jQuery( '#site-navigation' ).zerifsubmenuorientation();
-} );
 ;(function ($, window) {
     var defaults = {
         // 'true'   -> if there is a big submenu all submenu will be aligned to the right
@@ -831,3 +828,6 @@ jQuery( document ).ready( function() {
       });
     }
 })(jQuery,window);
+jQuery( document ).ready( function() {
+  jQuery( '#site-navigation' ).zerifsubmenuorientation();
+} );


### PR DESCRIPTION
After activating the W3 Total Cache  Minify Auto shows an error console about the function zerifsubmenuorientation dosen't exists.
This PR change solve by only call the function after there declaration.