### PR TITLE
Inform users that theme requires at least PHP 5.4

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -30,6 +30,34 @@ function zerif_load_sdk( $products ) {
 	return $products;
 }
 
+/**
+ * Adds notice for PHP < 5.3.29 hosts.
+ */
+function zerif_php_support() {
+	$message = sprintf(
+	/* translators: %s - message to upgrade PHP to the latest version */
+		__( 'Hey, we\'ve noticed that you\'re running an outdated version of PHP which is no longer supported. Make sure your site is fast and secure, by %s. Zelle\'s minimal requirement is PHP 5.4.0.', 'zerif-lite' ),
+		sprintf(
+		/* translators: %s message to upgrade PHP to the latest version */
+			'<a href="https://wordpress.org/support/upgrade-php/">%s</a>',
+			__( 'upgrading PHP to the latest version', 'zerif-lite' )
+		)
+	);
+
+	printf( '<div class="error"><p>%1$s</p></div>', wp_kses_post( $message ) );
+}
+
+if ( version_compare( PHP_VERSION, '5.3.29' ) < 0 ) {
+	/**
+	 * Add notice for PHP upgrade.
+	 */
+	add_filter( 'template_include', '__return_null' );
+	switch_theme( WP_DEFAULT_THEME );
+	unset( $_GET['activated'] );
+	add_action( 'admin_notices', 'zerif_php_support', 99 );
+	return;
+}
+
 if ( ! defined( 'ELEMENTOR_PARTNER_ID' ) ) {
 	define( 'ELEMENTOR_PARTNER_ID', 2112 );
 }
@@ -503,34 +531,6 @@ function zerif_setup() {
 }
 
 add_action( 'after_setup_theme', 'zerif_setup' );
-
-/**
- * Add compatibility with WooCommerce Product Images customizer controls.
- */
-function zerif_set_woo_image_sizes() {
-
-	$execute = get_option( 'zerif_update_woocommerce_customizer_controls', false );
-	if ( $execute !== false ) {
-		return;
-	}
-
-	update_option( 'woocommerce_thumbnail_cropping', 'custom' );
-	update_option( 'woocommerce_thumbnail_cropping_custom_width', '3' );
-	update_option( 'woocommerce_thumbnail_cropping_custom_height', '2' );
-
-	if ( class_exists( 'WC_Regenerate_Images' ) ) {
-		$regenerate_obj = new WC_Regenerate_Images();
-		$regenerate_obj::init();
-		if ( method_exists( $regenerate_obj, 'maybe_regenerate_images' ) ) {
-			$regenerate_obj::maybe_regenerate_images();
-		} elseif ( method_exists( $regenerate_obj, 'maybe_regenerate_images_option_update' ) ) {
-			// Force woocommerce 3.3.1 to regenerate images
-			$regenerate_obj::maybe_regenerate_images_option_update( 1, 2, '' );
-		}
-	}
-
-	update_option( 'zerif_update_woocommerce_customizer_controls', true );
-}
 
 
 /**


### PR DESCRIPTION
Show notice instead of activating the theme and give fatal error when PHP version is lower than 5.3.29

#702